### PR TITLE
Refactor auth service and configure environments

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,6 +30,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,35 +1,158 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable, finalize, tap } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface User {
+  id: string;
+  email?: string;
+  username?: string;
+  [key: string]: unknown;
+}
+
+interface AuthResponse {
+  accessToken?: string;
+  user?: User | null;
+  [key: string]: unknown;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
-  private apiUrl = 'http://localhost:8081/auth';
-  private isLoggedInState = false;
+  private readonly tokenStorageKey = 'token';
+  private readonly apiUrl = `${environment.apiBaseUrl}/auth`;
+  private readonly authStateSubject = new BehaviorSubject<User | null>(null);
+  readonly authState$ = this.authStateSubject.asObservable();
 
-  constructor(private http: HttpClient) {}
+  private accessToken: string | null = null;
 
-  registerUser(userData: any): Observable<any> {
-    return this.http.post(`${this.apiUrl}/register`, userData);
+  constructor(private http: HttpClient) {
+    const storedToken = localStorage.getItem(this.tokenStorageKey);
+    if (storedToken) {
+      this.accessToken = storedToken;
+    }
   }
 
-  loginUser(credentials: any): Observable<any> {
-    return this.http.post(`${this.apiUrl}/login`, credentials);
+  get token(): string | null {
+    return this.accessToken;
   }
 
-  login() {
-    this.isLoggedInState = true;
-    localStorage.setItem('loggedIn', 'true');
+  isAuthenticated(): boolean {
+    return !!this.accessToken;
   }
 
-  logout() {
-    this.isLoggedInState = false;
-    localStorage.removeItem('loggedIn');
+  login(credentials: Record<string, unknown>): Observable<AuthResponse> {
+    return this.http
+      .post<AuthResponse>(
+        `${this.apiUrl}/login`,
+        credentials,
+        this.getHttpOptions()
+      )
+      .pipe(
+        tap((response) => {
+          this.handleToken(response?.accessToken ?? null);
+          this.nextAuthState(response?.user ?? null);
+        })
+      );
+  }
+
+  register(userData: Record<string, unknown>): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(
+      `${this.apiUrl}/register`,
+      userData,
+      this.getHttpOptions()
+    );
+  }
+
+  forgotPassword(payload: Record<string, unknown>): Observable<void> {
+    return this.http.post<void>(
+      `${this.apiUrl}/forgot-password`,
+      payload,
+      this.getHttpOptions()
+    );
+  }
+
+  resetPassword(payload: Record<string, unknown>): Observable<void> {
+    return this.http.post<void>(
+      `${this.apiUrl}/reset-password`,
+      payload,
+      this.getHttpOptions()
+    );
+  }
+
+  refresh(): Observable<AuthResponse> {
+    return this.http
+      .post<AuthResponse>(`${this.apiUrl}/refresh`, {}, this.getHttpOptions())
+      .pipe(
+        tap((response) => {
+          this.handleToken(response?.accessToken ?? null);
+          this.nextAuthState(
+            response?.user ?? undefined,
+            /* emitCurrentWhenUndefined */ true
+          );
+        })
+      );
+  }
+
+  logout(): Observable<void> {
+    return this.http
+      .post<void>(`${this.apiUrl}/logout`, {}, this.getHttpOptions())
+      .pipe(finalize(() => this.clearAuth()));
+  }
+
+  me(): Observable<User> {
+    return this.http
+      .get<User>(`${this.apiUrl}/me`, this.getHttpOptions())
+      .pipe(tap((user) => this.nextAuthState(user)));
+  }
+
+  registerUser(userData: Record<string, unknown>): Observable<AuthResponse> {
+    return this.register(userData);
+  }
+
+  loginUser(credentials: Record<string, unknown>): Observable<AuthResponse> {
+    return this.login(credentials);
   }
 
   isLoggedIn(): boolean {
-    return localStorage.getItem('loggedIn') === 'true';
+    return this.isAuthenticated();
+  }
+
+  private getHttpOptions() {
+    return environment.useCredentials ? { withCredentials: true } : {};
+  }
+
+  private handleToken(token: string | null): void {
+    if (token) {
+      this.accessToken = token;
+      localStorage.setItem(this.tokenStorageKey, token);
+    } else {
+      this.clearToken();
+    }
+  }
+
+  private nextAuthState(
+    user: User | null | undefined,
+    emitCurrentWhenUndefined = false
+  ): void {
+    if (user === undefined) {
+      if (emitCurrentWhenUndefined) {
+        this.authStateSubject.next(this.authStateSubject.value);
+      }
+      return;
+    }
+
+    this.authStateSubject.next(user);
+  }
+
+  private clearAuth(): void {
+    this.clearToken();
+    this.authStateSubject.next(null);
+  }
+
+  private clearToken(): void {
+    this.accessToken = null;
+    localStorage.removeItem(this.tokenStorageKey);
   }
 }

--- a/src/app/features/auth/pages/register/register.component.ts
+++ b/src/app/features/auth/pages/register/register.component.ts
@@ -37,7 +37,7 @@ export class RegisterComponent {
       return;
     }
 
-    this.authService.registerUser(this.registerForm.value).subscribe({
+    this.authService.register(this.registerForm.value).subscribe({
       next: () => {
         alert('✅ Registration successful! You can now log in.');
         this.router.navigate(['/auth/login']);

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
 import { CommonModule } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-layout-header',
@@ -16,6 +17,11 @@ export class HeaderLayoutComponent {
 
   constructor(private authService: AuthService, private router: Router) {
     this.isAuthenticated = this.authService.isLoggedIn();
+    this.authService.authState$
+      .pipe(takeUntilDestroyed())
+      .subscribe((user) => {
+        this.isAuthenticated = !!user || this.authService.isAuthenticated();
+      });
   }
 
   toggleMenu() {
@@ -29,7 +35,9 @@ export class HeaderLayoutComponent {
 
   logout() {
     this.menuOpen = false;
-    this.authService.logout();
-    this.router.navigate(['/']);
+    this.authService.logout().subscribe({
+      next: () => this.router.navigate(['/']),
+      error: () => this.router.navigate(['/']),
+    });
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  apiBaseUrl: '/api',
+  useCredentials: true,
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  apiBaseUrl: '/api',
+  useCredentials: true,
+};


### PR DESCRIPTION
## Summary
- add Angular environment files and configure production replacements
- refactor the auth service to use environment-driven endpoints, token persistence, and BehaviorSubject auth state
- update header and register components to consume the new auth service API

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cadb1c2ec88321bef10e416d89b4dc