### PR TITLE
feat: add jwt interceptor refresh handling

### DIFF
--- a/src/app/core/interceptors/jwt.interceptor.spec.ts
+++ b/src/app/core/interceptors/jwt.interceptor.spec.ts
@@ -1,0 +1,147 @@
+import { HttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { jwtInterceptor } from './jwt.interceptor';
+import { AuthService } from '../services/auth.service';
+
+class MockAuthService {
+  private _token: string | null = null;
+  nextRefreshToken: string | null = null;
+
+  readonly refresh = jasmine
+    .createSpy('refresh')
+    .and.callFake(() => {
+      this._token = this.nextRefreshToken;
+      return of({ accessToken: this.nextRefreshToken ?? undefined });
+    });
+
+  readonly logout = jasmine
+    .createSpy('logout')
+    .and.returnValue(of(void 0));
+
+  get token(): string | null {
+    return this._token;
+  }
+
+  setToken(token: string | null): void {
+    this._token = token;
+  }
+}
+
+describe('jwtInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let authService: MockAuthService;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    authService = new MockAuthService();
+    router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router },
+        provideHttpClient(withInterceptors([jwtInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should append the bearer token for API requests', () => {
+    authService.setToken('token-123');
+
+    let responseBody: string | undefined;
+    http.get<string>('/api/data').subscribe((response) => {
+      responseBody = response;
+    });
+
+    const request = httpMock.expectOne('/api/data');
+    expect(request.request.headers.get('Authorization')).toBe(
+      'Bearer token-123'
+    );
+    request.flush('success');
+
+    expect(responseBody).toBe('success');
+    expect(authService.refresh).not.toHaveBeenCalled();
+  });
+
+  it('should refresh the token and retry the request once', () => {
+    authService.setToken('expired-token');
+    authService.nextRefreshToken = 'new-token';
+
+    let responseBody: string | undefined;
+    http.get<string>('/api/data').subscribe((response) => {
+      responseBody = response;
+    });
+
+    const initialRequest = httpMock.expectOne('/api/data');
+    expect(initialRequest.request.headers.get('Authorization')).toBe(
+      'Bearer expired-token'
+    );
+    initialRequest.flush('Unauthorized', {
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    expect(authService.refresh).toHaveBeenCalledTimes(1);
+
+    const retriedRequest = httpMock.expectOne('/api/data');
+    expect(retriedRequest.request.headers.get('Authorization')).toBe(
+      'Bearer new-token'
+    );
+    retriedRequest.flush('final-response');
+
+    expect(responseBody).toBe('final-response');
+    expect(authService.logout).not.toHaveBeenCalled();
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('should logout and redirect when the retried request is unauthorized', (done) => {
+    authService.setToken('expired-token');
+    authService.nextRefreshToken = 'new-token';
+
+    http.get<string>('/api/data').subscribe({
+      next: () => {
+        fail('Request should not succeed after repeated 401 responses');
+      },
+      error: (error) => {
+        expect(error.status).toBe(401);
+        expect(authService.logout).toHaveBeenCalledTimes(1);
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/login');
+        done();
+      },
+    });
+
+    const initialRequest = httpMock.expectOne('/api/data');
+    expect(initialRequest.request.headers.get('Authorization')).toBe(
+      'Bearer expired-token'
+    );
+    initialRequest.flush('Unauthorized', {
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    const retriedRequest = httpMock.expectOne('/api/data');
+    expect(retriedRequest.request.headers.get('Authorization')).toBe(
+      'Bearer new-token'
+    );
+    retriedRequest.flush('Unauthorized', {
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+  });
+});

--- a/src/app/core/interceptors/jwt.interceptor.ts
+++ b/src/app/core/interceptors/jwt.interceptor.ts
@@ -1,11 +1,126 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import {
+  HttpContextToken,
+  HttpErrorResponse,
+  HttpInterceptorFn,
+  HttpRequest,
+} from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  Observable,
+  catchError,
+  finalize,
+  of,
+  shareReplay,
+  switchMap,
+  throwError,
+} from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { AuthService } from '../services/auth.service';
+
+const RETRY_ATTEMPTED = new HttpContextToken<boolean>(() => false);
+const API_PREFIX = environment.apiBaseUrl.endsWith('/')
+  ? environment.apiBaseUrl.slice(0, -1)
+  : environment.apiBaseUrl;
+let refreshRequest$: Observable<string | null> | null = null;
+
+const getRequestPath = (request: HttpRequest<unknown>): string => {
+  if (request.url.startsWith('http')) {
+    try {
+      return new URL(request.url).pathname;
+    } catch {
+      return request.url;
+    }
+  }
+
+  return request.url;
+};
+
+const isApiRequest = (request: HttpRequest<unknown>): boolean =>
+  getRequestPath(request).startsWith(API_PREFIX);
+
+const isAuthRefreshRequest = (request: HttpRequest<unknown>): boolean =>
+  getRequestPath(request).startsWith(`${API_PREFIX}/auth/refresh`);
+
+const addAuthorizationHeader = (
+  request: HttpRequest<unknown>,
+  token: string
+): HttpRequest<unknown> =>
+  request.clone({
+    setHeaders: { Authorization: `Bearer ${token}` },
+  });
+
+const getRefreshObservable = (authService: AuthService): Observable<string | null> => {
+  if (!refreshRequest$) {
+    refreshRequest$ = authService.refresh().pipe(
+      switchMap((response) => of(response?.accessToken ?? authService.token)),
+      shareReplay({ bufferSize: 1, refCount: true }),
+      finalize(() => {
+        refreshRequest$ = null;
+      })
+    );
+  }
+
+  return refreshRequest$;
+};
+
+const logoutAndRedirect = (
+  error: HttpErrorResponse,
+  authService: AuthService,
+  router: Router
+) =>
+  authService
+    .logout()
+    .pipe(
+      catchError(() => of(void 0)),
+      switchMap(() => {
+        void router.navigateByUrl('/login');
+        return throwError(() => error);
+      })
+    );
 
 export const jwtInterceptor: HttpInterceptorFn = (req, next) => {
-  const token = localStorage.getItem('token');
-  if (token) {
-    req = req.clone({
-      setHeaders: { Authorization: `Bearer ${token}` },
-    });
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!isApiRequest(req)) {
+    return next(req);
   }
-  return next(req);
+
+  let authRequest = req;
+  const token = authService.token;
+
+  if (token) {
+    authRequest = addAuthorizationHeader(authRequest, token);
+  }
+
+  return next(authRequest).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status !== 401 || isAuthRefreshRequest(authRequest)) {
+        return throwError(() => error);
+      }
+
+      if (authRequest.context.get(RETRY_ATTEMPTED)) {
+        return logoutAndRedirect(error, authService, router);
+      }
+
+      return getRefreshObservable(authService).pipe(
+        switchMap((newToken) => {
+          if (!newToken) {
+            return logoutAndRedirect(error, authService, router);
+          }
+
+          const retryRequest = addAuthorizationHeader(
+            authRequest.clone({
+              context: authRequest.context.set(RETRY_ATTEMPTED, true),
+            }),
+            newToken
+          );
+
+          return next(retryRequest);
+        }),
+        catchError(() => logoutAndRedirect(error, authService, router))
+      );
+    })
+  );
 };


### PR DESCRIPTION
## Summary
- enhance the JWT interceptor to append tokens, refresh once on 401, and force logout on repeated failures
- prevent concurrent refresh calls with a shared observable and ensure API-only interception
- add unit tests covering successful auth, refresh retry, and forced logout scenarios

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cadcde5b0883218ff219455f4c77b0