### PR TITLE
feat(auth): add standalone auth pages and guard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,10 +1,17 @@
 import { Routes } from '@angular/router';
 import { BeachMapComponent } from './features/beaches/pages/beach-map/beach-map.component';
+import { AuthGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
   { path: '', component: BeachMapComponent, pathMatch: 'full' },
   {
+    path: 'auth',
+    loadChildren: () =>
+      import('./features/auth/auth.routes').then((m) => m.authRoutes),
+  },
+  {
     path: 'beaches',
+    canActivateChild: [AuthGuard],
     loadChildren: () =>
       import('./features/beaches/beaches.routes').then((m) => m.beachesRoutes),
   },

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  CanActivateChild,
+  CanMatch,
+  Route,
+  Router,
+  RouterStateSnapshot,
+  UrlSegment,
+  UrlTree,
+} from '@angular/router';
+import { Observable, map, of, take } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate, CanActivateChild, CanMatch {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly router: Router
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> {
+    return this.resolveAccess(route, state.url);
+  }
+
+  canActivateChild(
+    childRoute: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> {
+    return this.resolveAccess(childRoute, state.url);
+  }
+
+  canMatch(route: Route, segments: UrlSegment[]): Observable<boolean | UrlTree> {
+    const url = `/${[route.path, ...segments.map((segment) => segment.path)]
+      .filter(Boolean)
+      .join('/')}`;
+
+    return this.resolveAccess(undefined, url, route);
+  }
+
+  private resolveAccess(
+    route: ActivatedRouteSnapshot | undefined,
+    url: string,
+    routeConfig?: Route
+  ): Observable<boolean | UrlTree> {
+    const isPublic = route?.data?.['public'] ?? routeConfig?.data?.['public'];
+    if (isPublic) {
+      return of(true);
+    }
+
+    if (this.authService.isAuthenticated()) {
+      return of(true);
+    }
+
+    return this.authService.authState$.pipe(
+      take(1),
+      map((user) => {
+        if (user || this.authService.isAuthenticated()) {
+          return true;
+        }
+
+        return this.router.createUrlTree(['/auth/login'], {
+          queryParams: { returnUrl: url },
+        });
+      })
+    );
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class RoleGuard implements CanActivate, CanActivateChild {
+  constructor(private readonly authService: AuthService) {}
+
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
+    return this.checkRoles(route);
+  }
+
+  canActivateChild(route: ActivatedRouteSnapshot): Observable<boolean> {
+    return this.checkRoles(route);
+  }
+
+  private checkRoles(route: ActivatedRouteSnapshot): Observable<boolean> {
+    const requiredRoles = route.data?.['roles'] as string[] | undefined;
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return of(true);
+    }
+
+    return this.authService.authState$.pipe(
+      take(1),
+      map((user) => {
+        const userRoles = (user?.['roles'] as string[] | undefined) ?? [];
+        return requiredRoles.every((role) => userRoles.includes(role));
+      })
+    );
+  }
+}

--- a/src/app/features/auth/auth.routes.ts
+++ b/src/app/features/auth/auth.routes.ts
@@ -1,11 +1,31 @@
 import { Routes } from '@angular/router';
 
 export const authRoutes: Routes = [
+  { path: '', pathMatch: 'full', redirectTo: 'login' },
+  {
+    path: 'login',
+    loadComponent: () =>
+      import('./pages/login/login.component').then((m) => m.LoginComponent),
+  },
   {
     path: 'register',
     loadComponent: () =>
       import('./pages/register/register.component').then(
         (m) => m.RegisterComponent
+      ),
+  },
+  {
+    path: 'forgot-password',
+    loadComponent: () =>
+      import('./pages/forgot-password/forgot-password.component').then(
+        (m) => m.ForgotPasswordComponent
+      ),
+  },
+  {
+    path: 'reset/:token',
+    loadComponent: () =>
+      import('./pages/reset-password/reset-password.component').then(
+        (m) => m.ResetPasswordComponent
       ),
   },
 ];

--- a/src/app/features/auth/pages/forgot-password/forgot-password.component.css
+++ b/src/app/features/auth/pages/forgot-password/forgot-password.component.css
@@ -1,16 +1,22 @@
-.register-container {
+.auth-container {
   max-width: 420px;
   margin: 50px auto;
   padding: 24px;
   border: 1px solid #ddd;
   border-radius: 12px;
-  background: #f8f9fa;
+  background: #ffffff;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
 }
 
 h2 {
   text-align: center;
   margin-bottom: 1rem;
+}
+
+.lead {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  color: #444;
 }
 
 label {
@@ -25,13 +31,6 @@ input {
   margin-top: 6px;
   border: 1px solid #ccc;
   border-radius: 6px;
-  transition: border-color 0.2s ease;
-}
-
-input:focus {
-  outline: none;
-  border-color: #2a628f;
-  box-shadow: 0 0 0 2px rgba(42, 98, 143, 0.1);
 }
 
 button {
@@ -44,7 +43,6 @@ button {
   border-radius: 6px;
   cursor: pointer;
   font-size: 1rem;
-  transition: background-color 0.2s ease;
 }
 
 button:hover:not(:disabled) {
@@ -65,7 +63,15 @@ button:disabled {
   color: #b3261e;
   text-align: center;
   margin-top: 14px;
-  font-size: 0.95rem;
+}
+
+.confirmation {
+  margin: 20px 0;
+  padding: 16px;
+  background: #e8f4ff;
+  border: 1px solid #b6daff;
+  border-radius: 8px;
+  color: #214c70;
 }
 
 .auth-link {

--- a/src/app/features/auth/pages/forgot-password/forgot-password.component.html
+++ b/src/app/features/auth/pages/forgot-password/forgot-password.component.html
@@ -1,0 +1,34 @@
+<div class="auth-container">
+  <h2>Forgot Password</h2>
+  <p class="lead">
+    Enter the email associated with your account and we will send you reset
+    instructions.
+  </p>
+
+  <form [formGroup]="requestForm" (ngSubmit)="onSubmit()" *ngIf="!submitted">
+    <label for="email">Email</label>
+    <input id="email" type="email" formControlName="email" required />
+    <div
+      *ngIf="requestForm.get('email')?.invalid && requestForm.get('email')?.touched"
+      class="error"
+    >
+      <small>⚠️ Enter a valid email address</small>
+    </div>
+
+    <button type="submit" [disabled]="requestForm.invalid || isSubmitting">
+      {{ isSubmitting ? 'Sending…' : 'Send reset link' }}
+    </button>
+
+    <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
+  </form>
+
+  <div class="confirmation" *ngIf="submitted">
+    <p>✅ If an account exists for this email, a reset link is on the way.</p>
+    <p>Please check your inbox and follow the instructions to reset your password.</p>
+  </div>
+
+  <p class="auth-link">
+    Remembered your password?
+    <a routerLink="/auth/login">Return to login</a>
+  </p>
+</div>

--- a/src/app/features/auth/pages/forgot-password/forgot-password.component.ts
+++ b/src/app/features/auth/pages/forgot-password/forgot-password.component.ts
@@ -1,0 +1,51 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { AuthService } from '../../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-forgot-password',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './forgot-password.component.html',
+  styleUrls: ['./forgot-password.component.css'],
+})
+export class ForgotPasswordComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+
+  requestForm: FormGroup = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+  });
+  submitted = false;
+  isSubmitting = false;
+  errorMessage = '';
+
+  onSubmit(): void {
+    if (this.requestForm.invalid || this.isSubmitting) {
+      this.requestForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.errorMessage = '';
+
+    this.authService.forgotPassword(this.requestForm.value).subscribe({
+      next: () => {
+        this.submitted = true;
+        this.isSubmitting = false;
+      },
+      error: (err) => {
+        this.errorMessage =
+          err?.error || '❌ Unable to process your request. Please try again.';
+        this.isSubmitting = false;
+      },
+    });
+  }
+}

--- a/src/app/features/auth/pages/login/login.component.css
+++ b/src/app/features/auth/pages/login/login.component.css
@@ -1,16 +1,16 @@
-.register-container {
+.auth-container {
   max-width: 420px;
   margin: 50px auto;
   padding: 24px;
   border: 1px solid #ddd;
   border-radius: 12px;
-  background: #f8f9fa;
+  background: #ffffff;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
 }
 
 h2 {
   text-align: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 label {
@@ -68,17 +68,20 @@ button:disabled {
   font-size: 0.95rem;
 }
 
-.auth-link {
+.auth-links {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   text-align: center;
-  margin-top: 1rem;
 }
 
-.auth-link a {
+.auth-links a {
   color: #2a628f;
   text-decoration: none;
   font-weight: 600;
 }
 
-.auth-link a:hover {
+.auth-links a:hover {
   text-decoration: underline;
 }

--- a/src/app/features/auth/pages/login/login.component.html
+++ b/src/app/features/auth/pages/login/login.component.html
@@ -1,0 +1,39 @@
+<div class="auth-container">
+  <h2>Welcome Back</h2>
+  <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
+    <label for="email">Email</label>
+    <input id="email" formControlName="email" type="email" required />
+    <div
+      *ngIf="loginForm.get('email')?.invalid && loginForm.get('email')?.touched"
+      class="error"
+    >
+      <small>⚠️ Enter a valid email address</small>
+    </div>
+
+    <label for="password">Password</label>
+    <input id="password" formControlName="password" type="password" required />
+    <div
+      *ngIf="
+        loginForm.get('password')?.invalid &&
+        loginForm.get('password')?.touched
+      "
+      class="error"
+    >
+      <small>⚠️ Password must be at least 6 characters long</small>
+    </div>
+
+    <button type="submit" [disabled]="loginForm.invalid || isSubmitting">
+      {{ isSubmitting ? 'Signing in...' : 'Sign in' }}
+    </button>
+
+    <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
+  </form>
+
+  <div class="auth-links">
+    <a routerLink="/auth/forgot-password">Forgot your password?</a>
+    <span>
+      New here?
+      <a routerLink="/auth/register">Create an account</a>
+    </span>
+  </div>
+</div>

--- a/src/app/features/auth/pages/login/login.component.ts
+++ b/src/app/features/auth/pages/login/login.component.ts
@@ -1,0 +1,57 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { AuthService } from '../../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css'],
+})
+export class LoginComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+
+  loginForm: FormGroup = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6)]],
+  });
+  errorMessage = '';
+  isSubmitting = false;
+
+  onSubmit(): void {
+    if (this.loginForm.invalid || this.isSubmitting) {
+      this.loginForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.errorMessage = '';
+
+    this.authService.login(this.loginForm.value).subscribe({
+      next: () => {
+        const returnUrl =
+          this.activatedRoute.snapshot.queryParamMap.get('returnUrl') || '/';
+        this.router.navigateByUrl(returnUrl);
+      },
+      error: (err) => {
+        this.errorMessage =
+          err?.error || '❌ Login failed. Please check your credentials.';
+        this.isSubmitting = false;
+      },
+      complete: () => {
+        this.isSubmitting = false;
+      },
+    });
+  }
+}

--- a/src/app/features/auth/pages/register/register.component.html
+++ b/src/app/features/auth/pages/register/register.component.html
@@ -1,46 +1,44 @@
 <div class="register-container">
-  <h2>Sign Up</h2>
+  <h2>Create an Account</h2>
   <form [formGroup]="registerForm" (ngSubmit)="onSubmit()">
-    <label for="username">Username:</label>
+    <label for="username">Username</label>
     <input id="username" formControlName="username" type="text" required />
     <div
-      *ngIf="
-        registerForm.controls.username.invalid &&
-        registerForm.controls.username.touched
-      "
+      *ngIf="registerForm.get('username')?.invalid && registerForm.get('username')?.touched"
+      class="error"
     >
       <small>⚠️ Username must be at least 3 characters long</small>
     </div>
 
-    <label for="email">Email:</label>
+    <label for="email">Email</label>
     <input id="email" formControlName="email" type="email" required />
     <div
-      *ngIf="
-        registerForm.controls.email.invalid &&
-        registerForm.controls.email.touched
-      "
+      *ngIf="registerForm.get('email')?.invalid && registerForm.get('email')?.touched"
+      class="error"
     >
       <small>⚠️ Enter a valid email address</small>
     </div>
 
-    <label for="phone">Phone Number:</label>
+    <label for="phone">Phone Number</label>
     <input id="phone" formControlName="phoneNumber" type="text" required />
     <div
       *ngIf="
-        registerForm.controls.phoneNumber.invalid &&
-        registerForm.controls.phoneNumber.touched
+        registerForm.get('phoneNumber')?.invalid &&
+        registerForm.get('phoneNumber')?.touched
       "
+      class="error"
     >
       <small>⚠️ Enter a valid phone number</small>
     </div>
 
-    <label for="password">Password:</label>
+    <label for="password">Password</label>
     <input id="password" formControlName="password" type="password" required />
     <div
       *ngIf="
-        registerForm.controls.password.invalid &&
-        registerForm.controls.password.touched
+        registerForm.get('password')?.invalid &&
+        registerForm.get('password')?.touched
       "
+      class="error"
     >
       <small>⚠️ Password must be at least 6 characters long</small>
     </div>
@@ -49,4 +47,9 @@
 
     <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
   </form>
+
+  <p class="auth-link">
+    Already have an account?
+    <a routerLink="/auth/login">Sign in</a>
+  </p>
 </div>

--- a/src/app/features/auth/pages/register/register.component.ts
+++ b/src/app/features/auth/pages/register/register.component.ts
@@ -1,24 +1,24 @@
 import { Component } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
-import { AuthService } from '../../../../core/services/auth.service';
 import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { AuthService } from '../../../../core/services/auth.service';
 
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.css'],
 })
 export class RegisterComponent {
   registerForm: FormGroup;
-  errorMessage: string = '';
+  errorMessage = '';
 
   constructor(
-    private fb: FormBuilder,
-    private authService: AuthService,
-    private router: Router
+    private readonly fb: FormBuilder,
+    private readonly authService: AuthService,
+    private readonly router: Router
   ) {
     this.registerForm = this.fb.group({
       username: ['', [Validators.required, Validators.minLength(3)]],
@@ -31,9 +31,10 @@ export class RegisterComponent {
     });
   }
 
-  onSubmit() {
+  onSubmit(): void {
     if (this.registerForm.invalid) {
       this.errorMessage = '⚠️ Please fill in all required fields correctly!';
+      this.registerForm.markAllAsTouched();
       return;
     }
 

--- a/src/app/features/auth/pages/reset-password/reset-password.component.css
+++ b/src/app/features/auth/pages/reset-password/reset-password.component.css
@@ -1,16 +1,22 @@
-.register-container {
+.auth-container {
   max-width: 420px;
   margin: 50px auto;
   padding: 24px;
   border: 1px solid #ddd;
   border-radius: 12px;
-  background: #f8f9fa;
+  background: #ffffff;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
 }
 
 h2 {
   text-align: center;
   margin-bottom: 1rem;
+}
+
+.lead {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  color: #444;
 }
 
 label {
@@ -25,13 +31,6 @@ input {
   margin-top: 6px;
   border: 1px solid #ccc;
   border-radius: 6px;
-  transition: border-color 0.2s ease;
-}
-
-input:focus {
-  outline: none;
-  border-color: #2a628f;
-  box-shadow: 0 0 0 2px rgba(42, 98, 143, 0.1);
 }
 
 button {
@@ -44,7 +43,6 @@ button {
   border-radius: 6px;
   cursor: pointer;
   font-size: 1rem;
-  transition: background-color 0.2s ease;
 }
 
 button:hover:not(:disabled) {
@@ -65,7 +63,22 @@ button:disabled {
   color: #b3261e;
   text-align: center;
   margin-top: 14px;
-  font-size: 0.95rem;
+}
+
+.confirmation {
+  margin-top: 20px;
+  padding: 16px;
+  background: #e8f4ff;
+  border: 1px solid #b6daff;
+  border-radius: 8px;
+  color: #214c70;
+  text-align: center;
+}
+
+.confirmation button {
+  width: auto;
+  margin-top: 12px;
+  padding: 10px 16px;
 }
 
 .auth-link {

--- a/src/app/features/auth/pages/reset-password/reset-password.component.html
+++ b/src/app/features/auth/pages/reset-password/reset-password.component.html
@@ -1,0 +1,53 @@
+<div class="auth-container">
+  <h2>Reset Your Password</h2>
+  <p class="lead" *ngIf="!resetComplete">
+    Choose a new password for your account. Make sure it is something secure and
+    easy for you to remember.
+  </p>
+
+  <form [formGroup]="resetForm" (ngSubmit)="onSubmit()" *ngIf="!resetComplete">
+    <label for="password">New Password</label>
+    <input id="password" type="password" formControlName="password" required />
+    <div
+      *ngIf="
+        resetForm.get('password')?.invalid && resetForm.get('password')?.touched
+      "
+      class="error"
+    >
+      <small>⚠️ Password must be at least 6 characters long</small>
+    </div>
+
+    <label for="confirmPassword">Confirm Password</label>
+    <input
+      id="confirmPassword"
+      type="password"
+      formControlName="confirmPassword"
+      required
+    />
+    <div
+      *ngIf="
+        resetForm.get('confirmPassword')?.invalid &&
+        resetForm.get('confirmPassword')?.touched
+      "
+      class="error"
+    >
+      <small>⚠️ Please confirm your new password</small>
+    </div>
+
+    <button type="submit" [disabled]="resetForm.invalid || isSubmitting">
+      {{ isSubmitting ? 'Updating…' : 'Update password' }}
+    </button>
+
+    <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
+  </form>
+
+  <div class="confirmation" *ngIf="resetComplete">
+    <p>✅ Your password has been updated successfully.</p>
+    <button type="button" (click)="returnToLogin()">Return to login</button>
+  </div>
+
+  <p class="auth-link" *ngIf="!resetComplete">
+    Remembered your password?
+    <a routerLink="/auth/login">Back to login</a>
+  </p>
+</div>

--- a/src/app/features/auth/pages/reset-password/reset-password.component.ts
+++ b/src/app/features/auth/pages/reset-password/reset-password.component.ts
@@ -1,0 +1,74 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { AuthService } from '../../../../core/services/auth.service';
+
+@Component({
+  selector: 'app-reset-password',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './reset-password.component.html',
+  styleUrls: ['./reset-password.component.css'],
+})
+export class ResetPasswordComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly authService = inject(AuthService);
+
+  private readonly token = this.route.snapshot.paramMap.get('token') ?? '';
+
+  resetForm: FormGroup = this.fb.group({
+    password: ['', [Validators.required, Validators.minLength(6)]],
+    confirmPassword: ['', [Validators.required]],
+  });
+
+  errorMessage = '';
+  isSubmitting = false;
+  resetComplete = false;
+
+  onSubmit(): void {
+    if (this.resetForm.invalid || this.isSubmitting) {
+      this.resetForm.markAllAsTouched();
+      return;
+    }
+
+    const { password, confirmPassword } = this.resetForm.value;
+    if (password !== confirmPassword) {
+      this.errorMessage = '⚠️ Passwords do not match.';
+      return;
+    }
+
+    if (!this.token) {
+      this.errorMessage = '❌ The reset link is invalid or has expired.';
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.errorMessage = '';
+
+    this.authService
+      .resetPassword({ token: this.token, password })
+      .subscribe({
+        next: () => {
+          this.resetComplete = true;
+          this.isSubmitting = false;
+        },
+        error: (err) => {
+          this.errorMessage =
+            err?.error || '❌ Unable to reset password. Please try again.';
+          this.isSubmitting = false;
+        },
+      });
+  }
+
+  returnToLogin(): void {
+    this.router.navigate(['/auth/login']);
+  }
+}

--- a/src/app/features/beaches/beaches.routes.ts
+++ b/src/app/features/beaches/beaches.routes.ts
@@ -8,6 +8,7 @@ export const beachesRoutes: Routes = [
         (m) => m.BeachListComponent
       ),
     pathMatch: 'full',
+    data: { public: true },
   },
   {
     path: ':id',
@@ -15,6 +16,7 @@ export const beachesRoutes: Routes = [
       import('./pages/beach-detail/beach-detail.component').then(
         (m) => m.BeachDetailComponent
       ),
+    data: { public: true },
   },
   {
     path: 'add',
@@ -36,5 +38,6 @@ export const beachesRoutes: Routes = [
       import('./pages/beach-map/beach-map.component').then(
         (m) => m.BeachMapComponent
       ),
+    data: { public: true },
   },
 ];

--- a/src/app/shared/components/header/header.component.css
+++ b/src/app/shared/components/header/header.component.css
@@ -1,11 +1,10 @@
-/* Основной стиль хедера */
 .header {
   display: flex;
   align-items: center;
   justify-content: flex-start;
   gap: 24px;
   padding: 15px 20px;
-  background: #2a628f; /* Deep Blue - цвет воды */
+  background: #2a628f;
   color: white;
   position: fixed;
   width: 100%;
@@ -24,7 +23,6 @@
   flex: 1;
 }
 
-/* Логотип */
 .logo {
   display: flex;
   align-items: center;
@@ -39,10 +37,9 @@
 
 .logo h1 {
   font-size: 1.5rem;
-  color: #e3c16f; /* Warm Sand - теплый оттенок */
+  color: #e3c16f;
 }
 
-/* Навигация */
 .nav {
   display: flex;
   gap: 20px;
@@ -53,10 +50,9 @@
 }
 
 .nav a {
-  color: #a1c181; /* Soft Green - природный цвет */
+  color: #a1c181;
   text-decoration: none;
   font-size: 1.1rem;
-  transition: 0.3s;
   padding: 5px 10px;
   border-radius: 5px;
 }
@@ -64,10 +60,9 @@
 .nav a:hover,
 .nav a.active {
   background: rgba(255, 255, 255, 0.2);
-  border-bottom: 2px solid #e3c16f; /* Warm Sand */
+  border-bottom: 2px solid #e3c16f;
 }
 
-/* Кнопки аутентификации */
 .auth-buttons {
   display: flex;
   align-items: center;
@@ -75,22 +70,29 @@
   margin-left: auto;
 }
 
-.auth-buttons button {
-  background: #f08a5d; /* Accent Orange */
+.auth-buttons button,
+.mobile-auth-buttons button {
+  background: #f08a5d;
   color: white;
   border: none;
   padding: 8px 15px;
   cursor: pointer;
   font-size: 1rem;
   border-radius: 5px;
-  transition: 0.3s;
 }
 
-.auth-buttons button:hover {
-  background: #c76c3f; /* Темнее для эффекта */
+.auth-buttons button.secondary,
+.mobile-auth-buttons button.secondary {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: white;
 }
 
-/* Бургер-меню */
+.auth-buttons button:hover,
+.mobile-auth-buttons button:hover {
+  background: #c76c3f;
+}
+
 .burger-menu {
   display: none;
   background: none;
@@ -101,7 +103,6 @@
   flex-shrink: 0;
 }
 
-/* Мобильное меню */
 .mobile-nav {
   display: none;
   flex-direction: column;
@@ -109,7 +110,7 @@
   top: 100px;
   left: 0;
   width: 100%;
-  background: #2a628f; /* Deep Blue */
+  background: #2a628f;
   padding: 15px 0;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
 }
@@ -132,10 +133,9 @@
 
 .mobile-auth-buttons button {
   flex: 0 1 auto;
-  min-width: 120px;
+  min-width: 110px;
 }
 
-/* Адаптивность */
 @media (max-width: 768px) {
   .header {
     gap: 16px;

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -14,12 +14,15 @@
     </nav>
 
     <div class="auth-buttons">
-      <ng-container
-        *ngTemplateOutlet="isAuthenticated ? logoutButton : loginButton"
-      ></ng-container>
+      <ng-container *ngIf="isAuthenticated; else loggedOut">
+        <button type="button" (click)="goToProfile()">Profile</button>
+        <button type="button" (click)="logout()">Logout</button>
+      </ng-container>
     </div>
 
-    <button class="burger-menu" type="button" (click)="toggleMenu()">☰</button>
+    <button class="burger-menu" type="button" (click)="toggleMenu()">
+      ☰
+    </button>
   </div>
 </header>
 
@@ -37,16 +40,19 @@
   >
 
   <div class="mobile-auth-buttons">
-    <ng-container
-      *ngTemplateOutlet="isAuthenticated ? logoutButton : loginButton"
-    ></ng-container>
+    <ng-container *ngIf="isAuthenticated; else mobileLoggedOut">
+      <button type="button" (click)="goToProfile()">Profile</button>
+      <button type="button" (click)="logout()">Logout</button>
+    </ng-container>
   </div>
 </nav>
 
-<ng-template #loginButton>
+<ng-template #loggedOut>
   <button type="button" (click)="login()">Login</button>
+  <button type="button" class="secondary" (click)="register()">Register</button>
 </ng-template>
 
-<ng-template #logoutButton>
-  <button type="button" (click)="logout()">Logout</button>
+<ng-template #mobileLoggedOut>
+  <button type="button" (click)="login()">Login</button>
+  <button type="button" class="secondary" (click)="register()">Register</button>
 </ng-template>

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -24,20 +24,34 @@ export class HeaderLayoutComponent {
       });
   }
 
-  toggleMenu() {
+  toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
   }
 
-  login() {
-    this.menuOpen = false;
+  login(): void {
+    this.closeMenu();
     this.router.navigate(['/auth/login']);
   }
 
-  logout() {
-    this.menuOpen = false;
+  register(): void {
+    this.closeMenu();
+    this.router.navigate(['/auth/register']);
+  }
+
+  goToProfile(): void {
+    this.closeMenu();
+    this.router.navigate(['/profile']);
+  }
+
+  logout(): void {
+    this.closeMenu();
     this.authService.logout().subscribe({
       next: () => this.router.navigate(['/']),
       error: () => this.router.navigate(['/']),
     });
+  }
+
+  private closeMenu(): void {
+    this.menuOpen = false;
   }
 }


### PR DESCRIPTION
## Summary
- add standalone login, register, forgot password, and reset password pages with reactive validation and UX updates
- introduce AuthGuard (and optional role guard), protecting beaches CRUD routes and exposing new auth child routes
- adjust header navigation to show login/register or profile/logout based on authentication state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cade4ed4ec83218a483c1ffcec3a7e