### PR TITLE
Enhance registration form validation and UX

### DIFF
--- a/src/app/features/auth/pages/register/register.component.css
+++ b/src/app/features/auth/pages/register/register.component.css
@@ -56,6 +56,24 @@ button:disabled {
   cursor: not-allowed;
 }
 
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  margin-right: 8px;
+  animation: spin 0.6s linear infinite;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .error {
   color: #b3261e;
   margin-top: 4px;

--- a/src/app/features/auth/pages/register/register.component.html
+++ b/src/app/features/auth/pages/register/register.component.html
@@ -9,6 +9,9 @@
     >
       <small>⚠️ Username must be at least 3 characters long</small>
     </div>
+    <div *ngIf="fieldErrors['username']?.length" class="error">
+      <small *ngFor="let message of fieldErrors['username']">{{ message }}</small>
+    </div>
 
     <label for="email">Email</label>
     <input id="email" formControlName="email" type="email" required />
@@ -17,6 +20,9 @@
       class="error"
     >
       <small>⚠️ Enter a valid email address</small>
+    </div>
+    <div *ngIf="fieldErrors['email']?.length" class="error">
+      <small *ngFor="let message of fieldErrors['email']">{{ message }}</small>
     </div>
 
     <label for="phone">Phone Number</label>
@@ -30,6 +36,11 @@
     >
       <small>⚠️ Enter a valid phone number</small>
     </div>
+    <div *ngIf="fieldErrors['phoneNumber']?.length" class="error">
+      <small *ngFor="let message of fieldErrors['phoneNumber']">
+        {{ message }}
+      </small>
+    </div>
 
     <label for="password">Password</label>
     <input id="password" formControlName="password" type="password" required />
@@ -40,10 +51,55 @@
       "
       class="error"
     >
-      <small>⚠️ Password must be at least 6 characters long</small>
+      <small *ngIf="registerForm.get('password')?.hasError('required')">
+        ⚠️ Password is required
+      </small>
+      <small
+        *ngIf="registerForm.get('password')?.hasError('passwordComplexity') &&
+        !registerForm.get('password')?.hasError('required')"
+      >
+        ⚠️ Password must be at least 8 characters and include a letter, number,
+        and special symbol
+      </small>
+    </div>
+    <div *ngIf="fieldErrors['password']?.length" class="error">
+      <small *ngFor="let message of fieldErrors['password']">{{ message }}</small>
     </div>
 
-    <button type="submit" [disabled]="registerForm.invalid">Register</button>
+    <label for="confirmPassword">Confirm Password</label>
+    <input
+      id="confirmPassword"
+      formControlName="confirmPassword"
+      type="password"
+      required
+    />
+    <div
+      *ngIf="
+        registerForm.get('confirmPassword')?.invalid &&
+        registerForm.get('confirmPassword')?.touched
+      "
+      class="error"
+    >
+      <small *ngIf="registerForm.get('confirmPassword')?.hasError('required')">
+        ⚠️ Please confirm your password
+      </small>
+      <small
+        *ngIf="registerForm.get('confirmPassword')?.hasError('passwordMismatch') &&
+        !registerForm.get('confirmPassword')?.hasError('required')"
+      >
+        ⚠️ Passwords do not match
+      </small>
+    </div>
+    <div *ngIf="fieldErrors['confirmPassword']?.length" class="error">
+      <small *ngFor="let message of fieldErrors['confirmPassword']">
+        {{ message }}
+      </small>
+    </div>
+
+    <button type="submit" [disabled]="registerForm.invalid || isSubmitting">
+      <span *ngIf="isSubmitting" class="spinner" aria-hidden="true"></span>
+      <span>{{ isSubmitting ? 'Creating account...' : 'Register' }}</span>
+    </button>
 
     <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
   </form>

--- a/src/app/features/auth/pages/register/register.component.ts
+++ b/src/app/features/auth/pages/register/register.component.ts
@@ -1,8 +1,16 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '../../../../core/services/auth.service';
+import { finalize } from 'rxjs';
 
 @Component({
   selector: 'app-register',
@@ -14,39 +22,154 @@ import { AuthService } from '../../../../core/services/auth.service';
 export class RegisterComponent {
   registerForm: FormGroup;
   errorMessage = '';
+  fieldErrors: Record<string, string[]> = {};
+  isSubmitting = false;
 
   constructor(
     private readonly fb: FormBuilder,
     private readonly authService: AuthService,
     private readonly router: Router
   ) {
-    this.registerForm = this.fb.group({
-      username: ['', [Validators.required, Validators.minLength(3)]],
-      email: ['', [Validators.required, Validators.email]],
-      phoneNumber: [
-        '',
-        [Validators.required, Validators.pattern('\\+?[0-9]{9,15}')],
-      ],
-      password: ['', [Validators.required, Validators.minLength(6)]],
-    });
+    this.registerForm = this.fb.group(
+      {
+        username: ['', [Validators.required, Validators.minLength(3)]],
+        email: ['', [Validators.required, Validators.email]],
+        phoneNumber: [
+          '',
+          [Validators.required, Validators.pattern('\\+?[0-9]{9,15}')],
+        ],
+        password: ['', [Validators.required]],
+        confirmPassword: ['', [Validators.required]],
+      },
+      { validators: this.passwordGroupValidator.bind(this) }
+    );
   }
 
   onSubmit(): void {
+    if (this.isSubmitting) {
+      return;
+    }
+
     if (this.registerForm.invalid) {
       this.errorMessage = '⚠️ Please fill in all required fields correctly!';
       this.registerForm.markAllAsTouched();
       return;
     }
 
-    this.authService.register(this.registerForm.value).subscribe({
+    this.isSubmitting = true;
+    this.errorMessage = '';
+    this.fieldErrors = {};
+
+    const { confirmPassword: _confirmPassword, ...payload } = this.registerForm.value;
+
+    this.authService
+      .register(payload)
+      .pipe(finalize(() => (this.isSubmitting = false)))
+      .subscribe({
       next: () => {
         alert('✅ Registration successful! You can now log in.');
         this.router.navigate(['/auth/login']);
       },
       error: (err) => {
-        this.errorMessage =
-          err.error || '❌ Registration failed. Please try again.';
+        this.handleRegistrationError(err?.error);
       },
     });
+  }
+
+  private passwordGroupValidator(control: AbstractControl): ValidationErrors | null {
+    const passwordControl = control.get('password');
+    const confirmPasswordControl = control.get('confirmPassword');
+
+    if (!passwordControl || !confirmPasswordControl) {
+      return null;
+    }
+
+    const password = passwordControl.value as string;
+    const confirmPassword = confirmPasswordControl.value as string;
+
+    const passwordPattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+
+    const passwordHasValue = !!password;
+    const passwordComplexityInvalid = passwordHasValue && !passwordPattern.test(password);
+    const passwordsMismatch =
+      passwordHasValue && !!confirmPassword && password !== confirmPassword;
+
+    this.setControlError(passwordControl, 'passwordComplexity', passwordComplexityInvalid);
+    this.setControlError(confirmPasswordControl, 'passwordMismatch', passwordsMismatch);
+
+    const errors: ValidationErrors = {};
+
+    if (passwordComplexityInvalid) {
+      errors['passwordComplexity'] = true;
+    }
+
+    if (passwordsMismatch) {
+      errors['passwordMismatch'] = true;
+    }
+
+    return Object.keys(errors).length ? errors : null;
+  }
+
+  private setControlError(
+    control: AbstractControl | null,
+    errorKey: string,
+    shouldSet: boolean
+  ): void {
+    if (!control) {
+      return;
+    }
+
+    const currentErrors = control.errors ?? {};
+
+    if (shouldSet) {
+      if (!currentErrors[errorKey]) {
+        control.setErrors({ ...currentErrors, [errorKey]: true });
+      }
+      return;
+    }
+
+    if (currentErrors[errorKey]) {
+      const { [errorKey]: _removed, ...remaining } = currentErrors;
+      control.setErrors(Object.keys(remaining).length ? remaining : null);
+    }
+  }
+
+  private handleRegistrationError(error: unknown): void {
+    this.errorMessage = '❌ Registration failed. Please try again.';
+
+    if (typeof error === 'string') {
+      this.errorMessage = error;
+      return;
+    }
+
+    if (error && typeof error === 'object') {
+      const errorObject = error as Record<string, unknown>;
+
+      const message = errorObject['message'] ?? errorObject['error'];
+      if (typeof message === 'string' && message.trim().length > 0) {
+        this.errorMessage = message;
+      }
+
+      const errors = errorObject['errors'];
+      if (errors && typeof errors === 'object') {
+        const normalizedErrors: Record<string, string[]> = {};
+        for (const [key, value] of Object.entries(errors as Record<string, unknown>)) {
+          if (value === undefined || value === null) {
+            continue;
+          }
+
+          normalizedErrors[key] = Array.isArray(value)
+            ? (value as unknown[]).map((item) => String(item))
+            : [String(value)];
+        }
+
+        if (Object.keys(normalizedErrors).length) {
+          this.fieldErrors = normalizedErrors;
+          if (!message) {
+            this.errorMessage = '';
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- enforce password/confirm-password validation with complexity checks and shared validator logic
- surface backend field errors alongside existing validation messaging and add a confirm-password input
- add a submitting state with disabled button and spinner feedback during registration

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cae0bc9a988321b70444e9e3971e1e