### PR TITLE
Configure Leaflet assets and API proxy

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,14 +18,23 @@
             "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
+            "allowedCommonJsDependencies": ["leaflet"],
             "assets": [
               {
                 "glob": "**/*",
                 "input": "public"
               },
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "node_modules/leaflet/dist/images",
+                "output": "assets/leaflet"
+              }
             ],
-            "styles": ["src/styles.css"],
+            "styles": [
+              "node_modules/leaflet/dist/leaflet.css",
+              "src/styles.css"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -60,6 +69,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "anda-fisher-f:build:production"
@@ -82,9 +94,17 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/leaflet/dist/images",
+                "output": "assets/leaflet"
               }
             ],
-            "styles": ["src/styles.css"],
+            "styles": [
+              "node_modules/leaflet/dist/leaflet.css",
+              "src/styles.css"
+            ],
             "scripts": []
           }
         }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,16 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import * as L from 'leaflet';
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
 import { jwtInterceptor } from './app/core/interceptors/jwt.interceptor';
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'assets/leaflet/marker-icon-2x.png',
+  iconUrl: 'assets/leaflet/marker-icon.png',
+  shadowUrl: 'assets/leaflet/marker-shadow.png',
+});
 
 bootstrapApplication(AppComponent, {
   providers: [

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,4 +31,15 @@ button:hover {
 button:disabled {
   background-color: #999;
   cursor: not-allowed;
-} /* You can add global styles to this file, and also import other style files */
+}
+
+/* Override Leaflet's default icon path to use locally served assets. */
+.leaflet-default-icon-path {
+  background-image: url('/assets/leaflet/marker-icon.png');
+}
+
+.leaflet-marker-icon.leaflet-interactive {
+  background-size: cover;
+}
+
+/* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
## Summary
- include Leaflet CSS and image assets in the Angular workspace configuration and allow CommonJS usage
- add a development proxy configuration that forwards /api requests to the backend service
- configure Leaflet icon URLs in the bootstrap code and override the default icon path in global styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae1e733dc8321b8fbb38e18708c7f