### PR TITLE
Add API proxy configuration to nginx frontend

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,16 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # API — проксируем на backend-сервис
+    location /api/ {
+        proxy_pass http://andafisher-backend:8081/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Статика — кэшируем подольше
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|otf|json)$ {
         expires 1y;


### PR DESCRIPTION
## Summary
- add an /api/ location block in nginx that forwards requests to the backend service while preserving client headers

## Testing
- ⚠️ `docker build -t andafisherfront:latest .` *(fails in CI container because docker is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cae2b5d0dc8321ae377517745525fb